### PR TITLE
Allow to access static arguments. Improve parsing logic for the static arguments

### DIFF
--- a/src/main/java/org/resthub/web/springmvc/router/Router.java
+++ b/src/main/java/org/resthub/web/springmvc/router/Router.java
@@ -584,6 +584,12 @@ public class Router {
             return args;
         }
 
+        public Map<String, String> getStaticArgs() {
+            return staticArgs;
+        }
+
+
+
         /**
          * HTTP method, e.g. "GET".
          */
@@ -603,7 +609,7 @@ public class Router {
         public String routesFile;
         static Pattern customRegexPattern = new Pattern("\\{([a-zA-Z_0-9]+)\\}");
         static Pattern argsPattern = new Pattern("\\{<([^>]+)>([a-zA-Z_0-9]+)\\}");
-        static Pattern paramPattern = new Pattern("([a-zA-Z_0-9]+):'(.*)'");
+        static Pattern paramPattern = new Pattern("\\s*([a-zA-Z_0-9]+)\\s*:\\s*'(.*)'\\s*");
 
         public void compute() {
             this.host = "";


### PR DESCRIPTION
There's an accessor for dynamic arguments in the Router class, but there's no way to access static arguments outside of the router class. It's useful to be able to access the static arguments as well. So this request creates a getter Router#getStaticArgs() similarly to Router#getArgs().

Secondary, now the static arguments must be typed in without any spaces between quotes, commas and colons. For example:

```
GET   /    FakeController.method(staticArg1:'value',staticArg2:'value')
```

This pull request allows having spaces between the argument making it less strict and less brittle. E.g.:

```
GET   /    FakeController.method(staticArg1 : 'value', staticArg2 : 'value')
```
