### PR TITLE
Using a different method to get the absolute path.

### DIFF
--- a/src/main/java/org/resthub/web/springmvc/router/Router.java
+++ b/src/main/java/org/resthub/web/springmvc/router/Router.java
@@ -163,7 +163,7 @@ public class Router {
      */
     static void parse(Resource fileResource) throws IOException {
 
-        String fileAbsolutePath = fileResource.getFile().getAbsolutePath();
+        String fileAbsolutePath = fileResource.getURL().getPath();
         String content = IOUtils.toString(fileResource.getInputStream());
 
         parse(content, fileAbsolutePath);


### PR DESCRIPTION
The method in this change uses an InputStream instead of a File object.

The use of a method that doesn't depends of a File object, makes possible a deploy into a WebLogic because with WebLogic the configuration files are loaded from a generated jar instead of a file in the filesystem.

The motivation for this change is in this issue: https://github.com/resthub/springmvc-router/issues/68 

I've tested myself this change with a simple spring boot project, using «gradle bootRun», delploying into a Tomcat server and into a WebLogic server. The three cases worked as expected.
